### PR TITLE
The random pattern often chooses some nodes that send traffic to themselves (weight 0)

### DIFF
--- a/simulator-sources/statistics.cpp
+++ b/simulator-sources/statistics.cpp
@@ -141,14 +141,14 @@ void insert_into_bucket_maxcon2(cable_cong_map_t *cable_cong, ptrn_t *ptrn, name
 		//get_max_congestion(&route, edge_list, &weight);
 		get_max_congestion(&route, cable_cong, &weight);
 		if (bucket->size() < weight + 1) {
-			bucket->resize( weight+10, 0);
+			bucket->resize(weight + 10, 0);
 			//bucket->at(weight) = 0;
 		}
 		bucket->at(weight) = bucket->at(weight) + 1;
 
 		/* The smae for bigbucket */
 		if (bigbucket.size() < weight + 1) {
-			bigbucket.resize( weight+10, 0);
+			bigbucket.resize(weight + 10, 0);
 		}
 		bigbucket.at(weight) = bigbucket.at(weight) + 1;
 	}


### PR DESCRIPTION
However, the function get_acc_bandwidth() asserts that there is no zero weight and the simulator crashes.

Rewrote the random function in a more efficient way, and takes into account that there should be no nodes communicating with themselves in the pattern.
