### PR TITLE
Added several new features/functionality. Fixed some crash-bugs.

### DIFF
--- a/simulator-sources/options_def.ggo
+++ b/simulator-sources/options_def.ggo
@@ -12,8 +12,9 @@ option  "num_runs" n "Number of simulation runs per pattern" int default="1" opt
 option  "ptrn" p "Which pattern to use" values="rand","null","bisect","bisect_fb_sym","tree","bruck","gather","scatter","ring","recdbl","2neighbor","4neighbor","6neighbor","ptrnvsptrn" default="bisect" optional
 option  "ptrnfst" f "Which pattern to use" values="rand","null","bisect","bisect_fb_sym","tree","bruck","gather","scatter","ring","recdbl","2neighbor","4neighbor","6neighbor" default="bisect" optional
 option  "ptrnsec" c "Which pattern to use" values="rand","null","bisect","bisect_fb_sym","tree","bruck","gather","scatter", "ring","recdbl","2neighbor","4neighbor","6neighbor" default="bisect" optional
-option  "subset" - "How to determine subset of nodes to use" values="rand","linear_bfs" default="rand" optional
+option  "subset" - "How to determine subset of nodes to use" values="rand","linear_bfs","guid_order_asc","guid_order_desc" default="rand" optional
 option  "metric" - "Which metric sould be used" values="sum_max_cong","hist_max_cong","hist_acc_band","dep_max_delay","get_cable_cong" default="hist_max_cong" optional
 option  "ptrn_level" l "Level of pattern" int default="-1" optional dependon="ptrn"
 option  "input_file" i "dot graph input file" string default="-" optional
 option  "output_file" o "histogram output file" string default="-" optional
+option  "node_ordering_file" z "if you need some of the nodes to have a fixed order and not participate in the suffling process between runs, you can provide a node order file with the guid of the nodes (one per line)" string default="-" optional

--- a/simulator-sources/simulator.hpp
+++ b/simulator-sources/simulator.hpp
@@ -8,6 +8,12 @@
 
 #define RUN 100
 #define ACCOUNT 101
+#define PARSE_GUID_BUFLEN  256
+
+/* IN and OUT are used to indicate if a function's
+ * parameter is used as input or output */
+#define IN
+#define OUT
 
 
 /* typedefs */
@@ -37,6 +43,7 @@ class used_edge_t {
 typedef std::vector<used_edge_t> used_edges_t;
 typedef std::map<edgeid_t, int> cable_cong_map_t;
 typedef std::vector<std::string> namelist_t;
+typedef std::vector<unsigned long long> guidlist_t;
 
 /* prototypes */
 void merge_two_patterns_into_one(ptrn_t *ptrn1, ptrn_t *ptrn2, int comm1_size, ptrn_t *ptrn_res);
@@ -55,17 +62,28 @@ void print_namelist(namelist_t *namelist);
 void generate_namelist_by_name(char *method, namelist_t *namelist, int comm_size);
 void generate_random_namelist(namelist_t *namelist, int comm_size);
 void generate_linear_namelist_bfs(namelist_t *namelist, int comm_size);
+void generate_linear_namelist_guid_order(namelist_t *namelist, int comm_size, bool asc);
 void shuffle_namelist(namelist_t *namelist);
 void simulate(used_edges_t *edge_list,  ptrn_t *ptrn, int num_runs);
 void find_route(uroute_t *route, std::string n1, std::string n2);
 int contains_target(char *comment, char *target);
-void get_name_list(namelist_t *namelist);
+unsigned long long convert_nodename_to_guid(std::string nodename);
+void get_guidlist_from_namelist(IN namelist_t *namelist,
+								OUT guidlist_t *guidlist);
+void get_namelist_from_guidlist(IN guidlist_t *guidlist,
+								IN namelist_t *complete_namelist,
+								OUT namelist_t *namelist);
+void get_namelist_from_graph(OUT namelist_t *namelist);
+void get_namelist_from_graph(OUT namelist_t *namelist,
+							 OUT guidlist_t *guidlist);
 void generate_random_mapping(named_ptrn_t *mapping, ptrn_t *ptrn);
 void insert_route_into_uedgelist(used_edges_t *edge_list, route_t *route);
 std::string lookup(int nodenumber, namelist_t *namelist);
 void printmapping(named_ptrn_t *mapping);
 void my_mpi_init(int *argc, char ***argv, int *rank, int *comm_size);
 void read_input_graph(char *filename);
+void read_node_ordering(IN char *filename,
+						OUT guidlist_t *guidorder_list);
 void bcast_namelist(namelist_t *namelist, int comm_size, int rank);
 void exchange_results(int mynode, int allnodes, double result);
 void exchange_results2(int mynode, int allnodes);


### PR DESCRIPTION
- Added two more options for the subset: "guid_order_asc" and "guid_order_desc" that will identify the subset by either sorting the node GUIDs in an ascending or descending order respectively.
- If the user chooses a larger commsize, the simulator crashes. Added a sanity check.
- Added a new parameter, --node_ordering_file, so that the user can provide a file with nodes that will have a fixed order and not participate in the shuffling. The file must be having the same format like the one accepted by opensm's parameter --guid_routing_order_file, i.e. one guid, given in a hex format, per line.
- A subset of nodes that will have a fixed position (node ordering) at the beginning of the namelist when running different patterns can be chosen with the --node_ordering_file parameter. This feature will always give the same results (unless the rand pattern is used), but we can use this to test different patterns with fixed node orderings and evaluate the quality of the routing.
- Improved the Hello message to notify the user that this hello is related to MPI and the MPI node rank.
- Added functions to convert namelists to a numeric guidlists.
  The numeric GUIDs are needed whenever we need to either choose a sorted subset or use the node ordering feature.
- Added a new final_namelist vector that is used for the simulations.
  If we have provided a nodeorder list, then we need to have one vector that we shuffle (the namelist) and one more ordered vector that we prepend to the shuffled namelist (the nodeorder_namelist).
- Added a dummy IN/OUT definition that can be used as indication in the different function so that the programmer can quickly find out if a function parameter is used as input or output.
