### PR TITLE
Fixed a bug in the command line argument parsing

### DIFF
--- a/get_network_graph/get_network_graph
+++ b/get_network_graph/get_network_graph
@@ -70,12 +70,6 @@ def int_to_hex_str(number, hex_length = -2, prefix_with_0x = False):
 
     return hex_str
 
-def stripspaces(str):
-    # erase whitespaces
-    p = re.compile("[\s]*");
-    str = p.sub( '', str)
-    return str
-
 r = quick_regexp()
 graph = {}
 lid_to_guid = {}

--- a/simulator-sources/options_def.ggo
+++ b/simulator-sources/options_def.ggo
@@ -17,4 +17,4 @@ option  "metric" - "Which metric sould be used" values="sum_max_cong","hist_max_
 option  "ptrn_level" l "Level of pattern" int default="-1" optional dependon="ptrn"
 option  "input_file" i "dot graph input file" string default="-" optional
 option  "output_file" o "histogram output file" string default="-" optional
-option  "node_ordering_file" z "if you need some of the nodes to have a fixed order and not participate in the suffling process between runs, you can provide a node order file with the guid of the nodes (one per line)" string default="-" optional
+option  "node_ordering_file" - "if you need some of the nodes to have a fixed order and not participate in the suffling process between runs, you can provide a node order file with the guid of the nodes (one per line)" string default="-" optional


### PR DESCRIPTION
I used -z option for the short version of the --node_ordering_file option, however, -z is already used by the partcomm_size option.
